### PR TITLE
Implement feature to save favourites in local storage

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -33,6 +33,14 @@ const App = () => {
             });
     }, []);
 
+    useEffect(() => {
+        getFavoritesFromLocalStorage();
+    }, [])
+
+    useEffect(() => {
+        saveInLocalStorage(favorites)
+    }, [favorites]);
+
     function handleThemeClick() {
         // setBackgroundColor("black");
         // setColor("white");
@@ -77,6 +85,18 @@ const App = () => {
         const filtered = favorites.filter((_current) => _current.id !== meme.id);
 
         setFavorites(filtered);
+    }
+
+    function saveInLocalStorage(favoritesArray) {
+        localStorage.setItem('favorites', JSON.stringify(favoritesArray));
+    }
+
+    function getFavoritesFromLocalStorage() {
+        const favorites = localStorage.getItem('favorites');
+        console.log('favorites:', favorites)
+        if (favorites || favorites.length) {
+            setFavorites(JSON.parse(favorites));
+        }
     }
 
     // **********************/

--- a/App.jsx
+++ b/App.jsx
@@ -20,8 +20,6 @@ const App = () => {
     const [query, setQuery] = useState(SEARCH_QUERY);
     const [resultsLimit, setResultsLimit] = useState(RESULTS_LIMIT);
     const [favorites, setFavorites] = useState([]);
-    console.log('favorites:', favorites)
-    console.log('local:', localStorage)
 
     useEffect(() => {
         axios
@@ -96,23 +94,6 @@ const App = () => {
 
     function getFavoritesFromLocalStorage() {
         const favorites = localStorage.getItem('favorites');
-        console.log('favorites:', favorites)
-        if (favorites || favorites.length) {
-            setFavorites(JSON.parse(favorites));
-        }
-    }
-
-    // function removeMemeFromLocalStorage(memeId) {
-
-    // }
-
-    function saveInLocalStorage(favoritesArray) {
-        localStorage.setItem('favorites', JSON.stringify(favoritesArray));
-    }
-
-    function getFavoritesFromLocalStorage() {
-        const favorites = localStorage.getItem('favorites');
-        console.log('favorites:', favorites)
         if (favorites || favorites.length) {
             setFavorites(JSON.parse(favorites));
         }

--- a/App.jsx
+++ b/App.jsx
@@ -20,6 +20,8 @@ const App = () => {
     const [query, setQuery] = useState(SEARCH_QUERY);
     const [resultsLimit, setResultsLimit] = useState(RESULTS_LIMIT);
     const [favorites, setFavorites] = useState([]);
+    console.log('favorites:', favorites)
+    console.log('local:', localStorage)
 
     useEffect(() => {
         axios
@@ -32,6 +34,15 @@ const App = () => {
                 setMemes(results);
             });
     }, []);
+
+    useEffect(() => {
+        getFavoritesFromLocalStorage();
+    }, [])
+    
+    useEffect(() => {
+        saveInLocalStorage(favorites)
+    }, [favorites]);
+
 
     function handleThemeClick() {
         // setBackgroundColor("black");
@@ -67,17 +78,34 @@ const App = () => {
         setFavorites((prevFaves) => prevFaves.concat(meme));
     }
 
+    
     function isMemeInFavorites(meme) {
         // locates first matching or returns undefined if not found
         return favorites.find((_current) => _current.id === meme.id);
     }
-
+    
     function removeFromFavorites(meme) {
         // filter favorites to remove this one
         const filtered = favorites.filter((_current) => _current.id !== meme.id);
-
+        
         setFavorites(filtered);
     }
+    
+    function saveInLocalStorage(favoritesArray) {
+        localStorage.setItem('favorites', JSON.stringify(favoritesArray));
+    }
+
+    function getFavoritesFromLocalStorage() {
+        const favorites = localStorage.getItem('favorites');
+        console.log('favorites:', favorites)
+        if (favorites || favorites.length) {
+            setFavorites(JSON.parse(favorites));
+        }
+    }
+
+    // function removeMemeFromLocalStorage(memeId) {
+
+    // }
 
     // **********************/
 


### PR DESCRIPTION
Solves issue #1 

Add useEffect that fires when favorites are updated to save memes in local storage. Also added another useEffect to get any favourites already stored in local storage. Refreshing the page persists favourites now.